### PR TITLE
updated sbt-plugin to 0.14.5 for sbt-assembly - tested compile locally

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 


### PR DESCRIPTION
Hi @magic-hat-solutions - sbt-assembly 0.14.4 is no longer available. Can you recreate the case notes 0.1.05 tag from this branch. Increment to 0.14.5 compiles successfully and passes integration tests locally. 

Unfortunately, I am unable to commit directly to the case notes repo, nor am I able to open a pull request direct to a tag.

if you merge this change into master and pull.. you can delete the tag:
git tag -d 0.1.05
git push --delete origin 0.1.05

Then you can merge the change:
git add projects/plugins.sbt
git commit -m "updated sbt-assembly dependency version"
git tag -a 0.1.05 -m "recreated tag with updated dependency version for sbt-assembly"
git push origin 0.1.05

I will then reactivate my mirror and build from the new source.
